### PR TITLE
Version 0.2.1

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -1,5 +1,76 @@
 # Operators
 
+## Default Operators
+
+### Equal
+
+- **id**: "equal"
+
+- **description**: Compares if the value of the object is equal to the value of the condition.
+
+
+### Not Equal
+
+- **id**: "not_equal"
+- **description**: Compares if the value of the object is not equal to the value of the condition.
+
+
+### Greater Than
+
+- **id**: "greater_than"
+
+- **description**: Compares if the value of the object is greater than the value of the condition.
+
+
+### Greater Than Inclusive
+
+- **id**: "greater_than_inclusive"
+
+- **description**: Compares if the value of the object is greater than or equal to the value of the condition.
+
+
+### Less Than
+
+- **id**: "less_than"
+
+- **description**: Compares if the value of the object is less than the value of the condition.
+
+
+### Less Than Inclusive
+
+- **id**: "less_than_inclusive"
+
+- **description**: Compares if the value of the object is less than or equal to the value of the condition.
+
+
+### In
+
+- **id**: "in"
+
+- **description**: Compares if the value of the object is in the value of the condition.
+
+
+### Not In
+
+- **id**: "not_in"
+
+- **description**: Compares if the value of the object is not in the value of the condition.
+
+
+### Contains
+
+- **id**: "contains"
+
+- **description**: Compares if the value of the object contains the value of the condition.
+
+
+### Not Contains
+
+- **id**: "not_contains"
+
+- **description**: Compares if the value of the object does not contain the value of the condition.
+
+
 ## Custom Operator
 
 To create your own operator you need to implement the `Operator` class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-rule-engine"
-version = "0.2.0"
+version = "0.2.1"
 description = "A rule engine where rules are written in JSON format"
 authors = ["Santiago Alvarez <santiago.salvarez@mercadolibre.com>"]
 homepage = "https://github.com/santalvarez/python-rule-engine"

--- a/src/python_rule_engine/models.py
+++ b/src/python_rule_engine/models.py
@@ -36,6 +36,8 @@ class MultiCondition(Condition):
 
 class Rule(BaseModel):
     name: str
+    description: str = None
+    extra: dict = None
     conditions: MultiCondition
 
 SimpleCondition.update_forward_refs()

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -11,6 +11,10 @@ def test_basic_rule_on_dict():
 
     rule = {
         "name": "basic_rule",
+        "description": "Basic rule to test the engine",
+        "extra": {
+            "some_field": "some_value"
+        },
         "conditions": {
             "all": [
                 {


### PR DESCRIPTION
Add `description` and `extra` fields to a rule.

The `extra` is an optional dict field that can be used to store additional information about the rule. This field will be ignored by the rule engine but will be included on the rule result.