### PR TITLE
Small RuleEngine improvements to ease inheretance

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/python_rule_engine/models/multi_condition.py
+++ b/src/python_rule_engine/models/multi_condition.py
@@ -16,7 +16,7 @@ class MultiCondition(Condition):
         self.all = self.__validate_conditions(data.get("all", []), data["operators_dict"])
         self.any = self.__validate_conditions(data.get("any", []), data["operators_dict"])
 
-    def __validate_conditions(self, data: List[dict], operators_dict) -> Optional[Condition]:
+    def __validate_conditions(self, data: List[dict], operators_dict) -> Optional[List[Condition]]:
         if not data:
             return None
         cds = []

--- a/src/python_rule_engine/models/rule.py
+++ b/src/python_rule_engine/models/rule.py
@@ -10,4 +10,3 @@ class Rule:
         conditions = validate_value(data.get("conditions"), dict, "conditions")
         conditions["operators_dict"] = operators_dict
         self.conditions = MultiCondition(**conditions)
-


### PR DESCRIPTION
Move `_merge_operators` and `_deserialize_rules` to public. This helps overwrite them in the child's class. It is useful, for example, to use own implementation Rule class in child RuleEngine.

Example:

```python
class OwnRule(Rule):

    @property
    is_pass(self):
        return self.conditions.match  


class OwnRuleEngine(RuleEngine):

    def _deserialize_rules(self, rules: List[Dict]) -> List[OwnRule]:
        aux_rules = []
        for rule in rules:
            aux_rules.append(OwnRule(rule, self.operators))
        return aux_rules
```

Move `default_operators` to public attribute. It helps to add new operators to the default list in the child class w/o overwrite _merge_operators.

Minor update in typings.
