### PR TITLE
fix: add Rule.event field to comply with json-rule-engine schema

### DIFF
--- a/src/python_rule_engine/models/rule.py
+++ b/src/python_rule_engine/models/rule.py
@@ -7,6 +7,7 @@ class Rule:
         self.name = validate_value(data.get("name"), str, "name")
         self.description = validate_value(data.get("description"), str, "description", nullable=True)
         self.extra = validate_value(data.get("extra"), dict, "extra", nullable=True)
+        self.event = validate_value(data.get("event"), dict, "event", nullable=True)
         conditions = validate_value(data.get("conditions"), dict, "conditions")
         conditions["operators_dict"] = operators_dict
         self.conditions = MultiCondition(**conditions)


### PR DESCRIPTION
We are using json-rule-engine in our frontend, while json-rule-engine supports the Rule.event field with some for advance event handling feature, here in event we can add data in Rule.event.params but since python-rule-engine doesn't have that field instead has Rule.extra. To keep using json-rule-engine and python-rule-engine we need this field.